### PR TITLE
Fixed remote logout

### DIFF
--- a/ssh_util.py
+++ b/ssh_util.py
@@ -63,8 +63,7 @@ class SSHUtil:
             if self.password is None:
                 # this needs to be a PEM key (begins with RSA not OPENSSH)
                 # use "ssh-keygen -p -m PEM -f id_rsa_X" to convert OPENSSH to RSA
-                self.pkey = paramiko.RSAKey.from_private_key_file(self.pkey)
-                self.client.connect(hostname=self.host, port=self.port, username=self.username, pkey=self.pkey,
+                self.client.connect(hostname=self.host, port=self.port, username=self.username, key_filename=self.pkey,
                                     timeout=self.timeout, allow_agent=False, look_for_keys=False)
                 print("Connected to the server", self.host)
             else:


### PR DESCRIPTION
A change was required in the way Paramiko client's `connect` function was called. Now instead of passing a `RSAKey` object created with a factory method provided by Paramiko we pass the filename of the private key itself. There is apparently another factory of a different kind of object (`PKey` IIRC) that is now used by the `pkey` parameter instead of `RSAKey`. I tried to use that and got an error. Meh, this works, no need to bang my head on that one.